### PR TITLE
Random walk over perf action space (only three actions).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 /dist
 /node_modules
 /package-lock.json
+.idea/

--- a/examples/hpctoolkit_service/__init__.py
+++ b/examples/hpctoolkit_service/__init__.py
@@ -127,12 +127,12 @@ class HPCToolkitDataset(Dataset):
             raise LookupError("Unknown program name")
 
 
-register(
-    id="hpctoolkit-llvm",
-    entry_point="compiler_gym.envs:CompilerEnv",
-    kwargs={
-        "service": HPCTOOLKIT_PY_SERVICE_BINARY,
-        "rewards": [RuntimeReward(), HPCToolkitReward()],
-        "datasets": [HPCToolkitDataset()],
-    },
-)
+# register(
+#     id="hpctoolkit-llvm",
+#     entry_point="compiler_gym.envs:CompilerEnv",
+#     kwargs={
+#         "service": HPCTOOLKIT_PY_SERVICE_BINARY,
+#         "rewards": [RuntimeReward(), HPCToolkitReward()],
+#         "datasets": [HPCToolkitDataset()],
+#     },
+# )

--- a/examples/hpctoolkit_service/agent_py/rewards/perf_reward.py
+++ b/examples/hpctoolkit_service/agent_py/rewards/perf_reward.py
@@ -19,12 +19,12 @@ class Reward(Reward):
         del benchmark  # unused
         perf_dict = pickle.loads(observation_view["perf"])
         self.baseline_cycles = int(perf_dict["cycles"])
-        print("Reward Perf: reset reward = ", self.baseline_cycles)
+        # print("Reward Perf: reset reward = ", self.baseline_cycles)
 
     def update(self, action, observations, observation_view):
         perf_dict = pickle.loads(observations[0])
         new_cycles = int(perf_dict["cycles"])
 
-        print("Reward Perf: update reward = ", new_cycles)
+        # print("Reward Perf: update reward = ", new_cycles)
 
         return float(self.baseline_cycles - new_cycles) / self.baseline_cycles

--- a/examples/hpctoolkit_service/service_py/benchmark_builder.py
+++ b/examples/hpctoolkit_service/service_py/benchmark_builder.py
@@ -155,7 +155,7 @@ class BenchmarkBuilder:
         compile_ll = deepcopy(self.compile_ll)
         compile_ll["opt"].insert(1, opt)
 
-        utils.print_list(compile_ll.values())
+        # utils.print_list(compile_ll.values())
         # pdb.set_trace()
 
         for cmd in compile_ll.values():

--- a/examples/hpctoolkit_service/service_py/example_service.py
+++ b/examples/hpctoolkit_service/service_py/example_service.py
@@ -38,27 +38,27 @@ import utils
 import signal
 import sys
 
-
+import gym
 
 class HPCToolkitCompilationSession(CompilationSession):
     """Represents an instance of an interactive compilation session."""
 
     compiler_version: str = "1.0.0"
 
+    llvm_env = gym.make("llvm-v0")
+
     action_spaces = [
         ActionSpace(
-            name="llvm",
+            name="llvm-hpctoolkit",
             choice=[
                 ChoiceSpace(
-                    name="optimization_choice",
+                    name="hpctoolkit-optimization_choice",
                     named_discrete_space=NamedDiscreteSpace(
-                        value=[
-                            "-O0",
-                            "-O1",
-                            "-O2",
-                            "-O3",
-                        ],
-                    ),
+                        # Use all flags from the llvm_env.
+                        value=llvm_env.action_space.flags,
+                        # Interpret NamedDiscrete as CommandLine.
+                        is_commandline=True
+                    )
                 )
             ],
         ),

--- a/examples/hpctoolkit_service/service_py/example_service.py
+++ b/examples/hpctoolkit_service/service_py/example_service.py
@@ -114,8 +114,8 @@ class HPCToolkitCompilationSession(CompilationSession):
         self._action_space = action_space
 
         os.chdir(str(working_directory))
-        print("\n", str(working_directory), "\n")
-        pdb.set_trace()
+        # print("\n", str(working_directory), "\n")
+        # pdb.set_trace()
 
         self.timeout_sec = timeout_sec
 

--- a/examples/hpctoolkit_service/service_py/profilers/perf.py
+++ b/examples/hpctoolkit_service/service_py/profilers/perf.py
@@ -58,8 +58,8 @@ class Profiler:
             + self.run_cmd
         )
 
-        print("\nPerf get_observations: ")
-        utils.print_list(perf_cmd)
+        # print("\nPerf get_observations: ")
+        # utils.print_list(perf_cmd)
 
         stdout = run_command(
             perf_cmd,

--- a/examples/random_walk_hpctoolkit.py
+++ b/examples/random_walk_hpctoolkit.py
@@ -1,0 +1,118 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Perform a random walk of the action space of a CompilerGym environment.
+
+Example usage:
+
+    # Run a random walk on cBench example program using perf runtime reward.
+    $ python random_walk_hpctoolkit.py --env=perf-v0 --step_min=100 --step_max=100   --benchmark=cbench-v1/qsort --reward=perf
+
+"""
+import random
+
+import humanize
+from absl import app, flags
+
+from compiler_gym.envs import CompilerEnv
+from compiler_gym.util.flags.benchmark_from_flags import benchmark_from_flags
+from compiler_gym.util.flags.env_from_flags import env_from_flags
+from compiler_gym.util.shell_format import emph
+from compiler_gym.util.timer import Timer
+
+flags.DEFINE_integer(
+    "step_min",
+    12,
+    "The minimum number of steps. Fewer steps may be performed if the "
+    "environment ends the episode early.",
+)
+flags.DEFINE_integer("step_max", 256, "The maximum number of steps.")
+FLAGS = flags.FLAGS
+
+
+def run_random_walk(env: CompilerEnv, step_count: int) -> None:
+    """Perform a random walk of the action space.
+
+    :param env: The environment to use.
+    :param step_count: The number of steps to run. This value is an upper bound -
+        fewer steps will be performed if any of the actions lead the
+        environment to end the episode.
+    """
+    rewards = []
+
+    step_num = 0
+    with Timer() as episode_time:
+        env.reset()
+        for step_num in range(1, step_count + 1):
+            action_index = env.action_space.sample()
+            with Timer() as step_time:
+                observation, reward, done, info = env.step(action_index)
+            print(
+                f"\n=== Step {humanize.intcomma(step_num)} ===\n"
+                f"Action:       {env.action_space.names[action_index]} "
+                f"(changed={not info.get('action_had_no_effect')})\n"
+                f"Reward:       {reward}"
+            )
+            rewards.append(reward)
+            if env.observation_space:
+                print(f"Observation:\n{observation}")
+            print(f"Step time:    {step_time}")
+            if done:
+                print("Episode ended by environment")
+                break
+
+    def reward_percentage(reward, rewards):
+        if sum(rewards) == 0:
+            return 0
+        percentage = reward / sum(rewards)
+        return emph(f"{'+' if percentage >= 0 else ''}{percentage:.2%}")
+
+    print(
+        f"\nCompleted {emph(humanize.intcomma(step_num))} steps in {episode_time} "
+        f"({step_num / episode_time.time:.1f} steps / sec).\n"
+        f"Total reward: {sum(rewards)}\n"
+        f"Max reward:   {max(rewards)} ({reward_percentage(max(rewards), rewards)} "
+        f"at step {humanize.intcomma(rewards.index(max(rewards)) + 1)})"
+    )
+
+
+def register_perf_session():
+    from compiler_gym.util.registration import register
+    from hpctoolkit_service.utils import HPCTOOLKIT_PY_SERVICE_BINARY
+    from hpctoolkit_service.agent_py.rewards import perf_reward
+    from compiler_gym.envs.llvm.datasets import CBenchDataset
+    from compiler_gym.util.runfiles_path import site_data_path
+
+    register(
+        id="perf-v0",
+        entry_point="compiler_gym.envs:CompilerEnv",
+        kwargs={
+            "service": HPCTOOLKIT_PY_SERVICE_BINARY,
+            "rewards": [perf_reward.Reward()],
+            "datasets": [
+                CBenchDataset(site_data_path("llvm-v0")),
+            ],
+        },
+    )
+
+
+def main(argv):
+    """Main entry point."""
+    assert len(argv) == 1, f"Unrecognized flags: {argv[1:]}"
+
+    # This two lines try to suppress logging to stdout.
+    import logging
+    logging.basicConfig(level=logging.CRITICAL, force=True)
+
+    register_perf_session()
+
+    # with gym.make("perf-v0") as env:
+    with env_from_flags(benchmark=benchmark_from_flags()) as env:
+        step_min = min(FLAGS.step_min, FLAGS.step_max)
+        step_max = max(FLAGS.step_min, FLAGS.step_max)
+        run_random_walk(env=env, step_count=random.randint(step_min, step_max))
+
+
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
The random walk example has been adapted to use the HPCToolkit compilation session with perf observation space. At this moment, the session supports only three actions in the action space. Logging is suppressed, and some prints are removed. 
Running 100 steps on `dijkstra` benchmark over `perf` observation spaces takes about 15s. Running the same number of steps for exploring `IrInstructionCount` space takes about 0.2s. I guess this is what we have expected.